### PR TITLE
Remove Files from Destination Instead of Deleting the Folder Itself

### DIFF
--- a/mynt/core.py
+++ b/mynt/core.py
@@ -346,9 +346,9 @@ class Mynt(object):
             if not self.opts['force']:
                 raise OptionException('Destination already exists.', 'the -f option must be used to force generation by deleting the destination')
             
-            self.dest.rm()
-        
-        self.dest.mk()
+            self.dest.clear()
+        else:
+            self.dest.mk()
         
         for page in self.pages:
             page.mk()

--- a/mynt/fs.py
+++ b/mynt/fs.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from codecs import open
 from datetime import datetime
-from os import makedirs, path as op, walk
+from os import makedirs, path as op, walk, unlink
 import shutil
 
 from mynt.utils import abspath, get_logger, normpath
@@ -30,6 +30,13 @@ class Directory(object):
             
             shutil.rmtree(self.path)
     
+    def clear(self):
+        if self.exists:
+            for root, dirs, files in walk(self.path):
+                for f in files:
+                    unlink(op.join(root, f))
+                for d in dirs:
+                    shutil.rmtree(op.join(root, d))
     
     @property
     def exists(self):


### PR DESCRIPTION
Hi!

I'm trying out mynt for a personal project.

I'm checking my generated output using SimpleHTTPServer like this:

```
cd _site
python -m SimpleHTTPServer
```

I can then look at my site through localhost:8000 to test it in different browsers on different virtual machines.

What's a bit annoying in this usecae is the fact that `mynt _site -f`will always delete the _site directory, rebuilding it afterwards. And this does not go well with SimpleHTTPServer (or other tools really, like symbolic links or folder-watch tools). 

I went ahead and changed the behavior of the generator to delete the contents of the destination folder instead of the folder itself, enabling me to use SimpleHTTPServer without restarting it after each generation.

Hopefully, you'll find this useful as well :)

In any case, thanks for mynt!

Denis
