### PR TITLE
Added permalink config to post

### DIFF
--- a/mynt/containers.py
+++ b/mynt/containers.py
@@ -58,7 +58,11 @@ class Post(object):
         
         if 'layout' not in self.frontmatter:
             raise PostException('Invalid post frontmatter.', 'src: {0}'.format(self.path), 'layout must be set')
-    
+   
+        if 'permalink' in self.frontmatter and self.frontmatter['permalink']:
+            self.permalink = self.frontmatter['permalink']
+        else:
+            self.permalink = None
     
     def _get_date(self, mtime, date):
         d = [None, None, None, 0, 0]

--- a/mynt/core.py
+++ b/mynt/core.py
@@ -141,7 +141,7 @@ class Mynt(object):
         
         return normpath(*parts)
     
-    def _get_post_url(self, date, slug):
+    def _get_post_url(self, date, slug, permalink=None):
         subs = {
             '<year>': '%Y',
             '<month>': '%m',
@@ -150,7 +150,8 @@ class Mynt(object):
             '<i_day>': '{0}'.format(date.day),
             '<title>': self._slugify(slug)
         }
-        
+        if permalink:
+            return permalink
         link = self.config['posts_url'].replace('%', '%%')
         
         for match, replace in subs.iteritems():
@@ -217,7 +218,7 @@ class Mynt(object):
                 'excerpt': excerpt,
                 'tags': [],
                 'timestamp': timegm(post.date.utctimetuple()),
-                'url': self._get_post_url(post.date, post.slug)
+                'url': self._get_post_url(post.date, post.slug, post.permalink)
             }
             
             data.update(post.frontmatter)


### PR DESCRIPTION
Hi Anomareh,
        I'm Sharmila and we have chated on irc before.  I've just added a small feature, i.e permalink as a config option for individual posts.  This will be very useful for people migrating from wordpress or other blogging software to mynt, while preserving their existing link structure.  This is a pull request for the same if you are interested.

And by the way, great work on the link being /year/month/slug/ rather than /year/month/slug.html.  Most useful when migrating from wordpress.
