### PR TITLE
Remove leading 4 spaces in code before pygmentizing

### DIFF
--- a/mynt/core.py
+++ b/mynt/core.py
@@ -211,6 +211,10 @@ class Mynt(object):
     def _highlight(self, match):
             language, code = match.groups()
             formatter = HtmlFormatter(linenos = 'table')
+
+            # remove markdown 4-space prefix for code
+            # ^\s{4,4} fails for empty lines b/w code
+            code = re.sub('(?m)^ {4,4}','',code)            
             
             for pattern, replace in [('&#34;', '"'), ('&#39;', '\''), ('&amp;', '&'), ('&apos;', '\''), ('&gt;', '>'), ('&lt;', '<'), ('&quot;', '"')]:
                 code = code.replace(pattern, replace)


### PR DESCRIPTION
When code is pygmentized, leading four spaces are not removed from markdown code lines (But they does for not-pygmentized code). This PR fixes it. However, now user is required to specify padding with CSS.
