### PR TITLE
Support for feed.xml for each tag

### DIFF
--- a/mynt/core.py
+++ b/mynt/core.py
@@ -44,6 +44,7 @@ class Mynt(object):
         'pygmentize': True,
         'renderer': 'jinja',
         'tag_layout': None,
+        'tag_feed_layout': 'feed.xml',
         'tags_url': '/',
         'version': __version__
     }
@@ -368,6 +369,10 @@ class Mynt(object):
                 self.pages.append(Page(
                     self._get_path(data['url']),
                     self._pygmentize(self.renderer.render(self.config['tag_layout'], {'tag': data}))
+                ))
+                self.pages.append(Page(
+                    self._get_path(data['url']).replace('index.html', self.config['tag_feed_layout']),
+                    self._pygmentize(self.renderer.render(self.config['tag_feed_layout'], {'tag': data}))
                 ))
         
         if self.config['archive_layout'] and self.archives:

--- a/mynt/themes/dark/_templates/feed.xml
+++ b/mynt/themes/dark/_templates/feed.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+{% if site.feed %}
+    <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>{{ site.title }}</title>
+        {% if site.subtitle %}<subtitle>{{ site.subtitle }}</subtitle>{% endif %}
+        <link rel="alternate" href="{{ get_url(absolute = true) }}" />
+        <link rel="self" href="{{ get_url('feed.xml', true) }}" type="application/atom+xml" />
+        <id>{{ get_url(absolute = true) }}</id>
+        <updated>{{ none|date('%Y-%m-%dT%H:%M:%SZ') }}</updated>
+        
+        <author>
+            <name>{{ site.author }}</name>
+            {% if site.email %}<email>{{ site.email }}</email>{% endif %}
+            <uri>{{ get_url(absolute = true) }}</uri>
+        </author>
+        
+        {% for post in posts[:20] %}
+           {% if tag.name in post.tags %}
+                <entry>
+                    <title>{{ post.title|escape }}</title>
+                    <link rel="alternate" href="{{ get_url(post.url, true) }}" type="text/html" />
+                    <id>{{ get_url(post.url, true) }}</id>
+                    <updated>{{ post.timestamp|date('%Y-%m-%dT%H:%M:%SZ') }}</updated>
+                
+                    {% if post.excerpt %}<summary type="html">{{ post.excerpt|absolutize|escape }}</summary>{% endif %}
+                    <content type="html">{{ post.content|absolutize|escape }}</content>
+                </entry>
+           {% endif %}
+        {% endfor %}
+    </feed>
+{% else %}
+    <!DOCTYPE disabled [<!ELEMENT disabled EMPTY>]>
+    <disabled/>
+{% endif %}

--- a/mynt/themes/light/_templates/feed.xml
+++ b/mynt/themes/light/_templates/feed.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+{% if site.feed %}
+    <feed xmlns="http://www.w3.org/2005/Atom">
+        <title>{{ site.title }}</title>
+        {% if site.subtitle %}<subtitle>{{ site.subtitle }}</subtitle>{% endif %}
+        <link rel="alternate" href="{{ get_url(absolute = true) }}" />
+        <link rel="self" href="{{ get_url('feed.xml', true) }}" type="application/atom+xml" />
+        <id>{{ get_url(absolute = true) }}</id>
+        <updated>{{ none|date('%Y-%m-%dT%H:%M:%SZ') }}</updated>
+        
+        <author>
+            <name>{{ site.author }}</name>
+            {% if site.email %}<email>{{ site.email }}</email>{% endif %}
+            <uri>{{ get_url(absolute = true) }}</uri>
+        </author>
+        
+        {% for post in posts[:20] %}
+           {% if tag.name in post.tags %}
+                <entry>
+                    <title>{{ post.title|escape }}</title>
+                    <link rel="alternate" href="{{ get_url(post.url, true) }}" type="text/html" />
+                    <id>{{ get_url(post.url, true) }}</id>
+                    <updated>{{ post.timestamp|date('%Y-%m-%dT%H:%M:%SZ') }}</updated>
+                
+                    {% if post.excerpt %}<summary type="html">{{ post.excerpt|absolutize|escape }}</summary>{% endif %}
+                    <content type="html">{{ post.content|absolutize|escape }}</content>
+                </entry>
+           {% endif %}
+        {% endfor %}
+    </feed>
+{% else %}
+    <!DOCTYPE disabled [<!ELEMENT disabled EMPTY>]>
+    <disabled/>
+{% endif %}


### PR DESCRIPTION
Hello,

I've added support for mynt to generate a feed.xml for each tag that is used in the blog posts.  I also added feed.xml to the _templates folders for the dark and light themes.  This also adds another possible variable for the config.yml file, "tag_feed_layout."

Thanks,
Jesse
