### PR TITLE
Convert input to join() to unicode

### DIFF
--- a/mynt/server.py
+++ b/mynt/server.py
@@ -32,7 +32,7 @@ class RequestHandler(SimpleHTTPRequestHandler):
             elif isinstance(v, str):
                 args[i] = v.decode('utf-8')
         
-        logger.debug('>> [{0}] {1}: {2}'.format(self.log_date_time_string(), self.address_string(), ' '.join(args)))
+        logger.debug('>> [{0}] {1}: {2}'.format(self.log_date_time_string(), self.address_string(), ' '.join(unicode(arg) for arg in args)))
 
 class Server(TCPServer):
     allow_reuse_address = True


### PR DESCRIPTION
I was getting this error before:

```
  File "/usr/local/lib/python2.7/site-packages/mynt/server.py", line 27, in log_message
    logger.debug('>> [{0}] {1}: {2}'.format(self.log_date_time_string(), self.address_string(), ' '.join(args)))
  TypeError: sequence item 0: expected string or Unicode, int found
```

It turned out that when I got a 404 the error code was sent to `join()` as an int which it can't handle. Hence I added a generator expression to convert all arguments to unicode before passing them to `join()`.
