### PR TITLE
Allow Python-Markdown as a parser

### DIFF
--- a/docs/docs/config/index.html
+++ b/docs/docs/config/index.html
@@ -173,6 +173,17 @@
         <dt id="renderer"><strong>renderer:</strong> <em>jinja</em></dt>
         <dd>The renderer used.</dd>
         
+        <dt id="filetypes"><strong>filetypes:</strong> <em>{}</em></dt>
+        <dd>
+            <p>A mapping of parsers to extensions. If more than one available parser supports an extension, you can explicitly define which is used here. The key is the name of the parser and the value is a list of extensions.</p>
+            <p>For example, to use the Python-Markdown parser over the default (Hoep):</p>
+            <pre><code data-lang="yaml">filetypes:
+  markdown:
+    - md
+    - markdown
+</code></pre>
+        </dd>
+        
         <dt id="tag_layout"><strong>tag_layout:</strong> <em>None</em></dt>
         <dd>
             <p>The template used to generate tag pages.</p>

--- a/docs/docs/config/index.html
+++ b/docs/docs/config/index.html
@@ -195,4 +195,22 @@
         <dt id="tags_url"><strong>tags_url:</strong> <em>/</em></dt>
         <dd>The base URL for tag pages.</dd>
     </dl>
+        
+    <h2 id="parser_options">Parser-specific Options</h2>
+    <p>Most parsers support optional features. To configure these, add a section with the parser's name, followed by a dictionary of options.</p>
+    <p>For example, to disable footnotes, and enable the underline extension for the default parser:</p>
+    <pre><code data-lang="yaml">hoep:
+  extensions:
+    footnotes: False
+    underline: True</code></pre>
+    <p>To tell the Python-Markdown parser to output HTML5, and disable line numbers in code blocks:</p>
+    <pre><code data-lang="yaml">markdown:
+  output_format: html5
+  extensions:
+    - extra
+    - codehilite
+  extension_configs:
+    codehilite:
+      linenums: False</code></pre>
+    <p>See the documentation for your chosen parser for available options.</p>
 {% endblock %}

--- a/docs/docs/quickstart/index.html
+++ b/docs/docs/quickstart/index.html
@@ -48,6 +48,9 @@
     <p>The recommended way to install mynt is via <a href="https://pip.pypa.io/en/latest/">pip</a>. If you already have pip installed, the below command is all you need. Otherwise, head on over to the pip site to get it <a href="https://pip.pypa.io/en/latest/installing.html">installed</a>.</p>
     <pre><code data-lang="text">$ pip install mynt</code></pre>
     <div class="notice notice-info">
+        <p>Mynt uses a wrapper around the Hoedown library by default. You can optionally add Python-Markdown support by installing with the following command:</p>
+        <pre><code data-lang="text">$ pip install mynt[Markdown]</code></pre>
+        <p>Use the <code>filetypes</code> config setting to enable it.</p>
         <p>If you'd like support for reStructuredText install mynt using the following command:</p>
         <pre><code data-lang="text">$ pip install mynt[reST]</code></pre>
     </div>

--- a/mynt/core.py
+++ b/mynt/core.py
@@ -44,6 +44,7 @@ class Mynt(object):
         'renderer': 'jinja',
         'tag_layout': None,
         'tags_url': '/',
+        'filetypes': {},
         'version': __version__
     }
     

--- a/mynt/parsers/pymd.py
+++ b/mynt/parsers/pymd.py
@@ -1,0 +1,21 @@
+from mynt.base import Parser as _Parser
+from markdown import Markdown
+
+
+class Parser(_Parser):
+    """Python-Markdown parser"""
+    accepts = ('.md', '.markdown', '.text')
+
+    defaults = {
+        'extensions': (
+            'extra',
+            'codehilite',
+        )
+    }
+
+    def parse(self, content):
+        return self._md.convert(content)
+
+    def setup(self):
+        config = self.options or self.defaults
+        self._md = Markdown(**config)

--- a/mynt/processors.py
+++ b/mynt/processors.py
@@ -56,6 +56,12 @@ class Reader(object):
                     self._extensions[extension] = [name]
             
             self._parsers[name] = Parser
+
+        # user-preferred parsers take precedence
+        for parser, extensions in self.site['filetypes'].items():
+            dot_ext = ['.' + ext for ext in extensions]
+            for ext in dot_ext:
+                self._extensions[ext] = [parser]
         
         for parsers in self._extensions.itervalues():
             parsers.sort(key = unicode.lower)

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
     entry_points = {
         'mynt.parsers' : [
             'docutils = mynt.parsers.docutils:Parser [reST]',
+            'markdown = mynt.parsers.pymd:Parser [Markdown]',
             'hoep = mynt.parsers.hoep:Parser'
         ],
         'mynt.renderers': [
@@ -93,6 +94,7 @@ setup(
         'watchdog'
     ],
     extras_require = {
+        'Markdown': 'Markdown',
         'reST': 'docutils>=0.10'
     },
     classifiers = [


### PR DESCRIPTION
Besides the obvious from the title:
- When more than one parser supports a given extension, Mynt will just pick the first one alphabetically. Because of that, there was no way to actually use the Python-Markdown parser (other than picking a different file extension for every file), so I added a way for users to control this behavior in the config. (See e9c7ff3) Let me know if you’d like this handled another way. Personally, I would just throw out the `accepts` property and let the association of extensions to parsers be completely configuration-driven, but I didn’t want to make any radical changes here.
- I added a section to the documentation explaining how to pass options to parsers. This behavior was already there, but it wasn’t documented anywhere from what I could see. I think we should also document the default options for each available parser (somewhere other than in the code), but I wasn’t sure where that should go.
